### PR TITLE
Change string type to []byte in function signature

### DIFF
--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -1,77 +1,69 @@
 package crypto
 
 import (
-	"encoding/hex"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/ripemd160"
 )
 
-func Blake256(data string) string {
+func Blake256(data []byte) ([]byte, error) {
 	b, _ := blake2b.New(32, nil)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 64)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Blake256WithKey(data string, key []byte) string {
+func Blake256WithKey(data []byte, key []byte) ([]byte, error) {
 	b, _ := blake2b.New(32, key)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 64)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Blake128(data string) string {
+func Blake128(data []byte) ([]byte, error) {
 	b, _ := blake2b.New(16, nil)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 32)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Blake128WithKey(data string, key []byte) string {
+func Blake128WithKey(data []byte, key []byte) ([]byte, error) {
 	b, _ := blake2b.New(16, key)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 32)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Blake160(data string) string {
+func Blake160(data []byte) ([]byte, error) {
 	b, _ := blake2b.New(20, nil)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 40)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Blake160WithKey(data string, key []byte) string {
+func Blake160WithKey(data []byte, key []byte) ([]byte, error) {
 	b, _ := blake2b.New(20, key)
-	s, _ := hex.DecodeString(data)
-	b.Write(s)
+	if _, err := b.Write(data); err != nil {
+		return nil, err
+	}
 	bs := b.Sum(nil)
-	var result = make([]byte, 40)
-	hex.Encode(result, bs[:])
-	return string(result)
+	return bs, nil
 }
 
-func Ripemd160(data string) string {
+func Ripemd160(data []byte) ([]byte, error) {
 	r := ripemd160.New()
-	s, _ := hex.DecodeString(data)
-	r.Write(s)
+	if _, err := r.Write(data); err != nil {
+		return nil, err
+	}
 	rs := r.Sum(nil)
-	var result = make([]byte, 40)
-	hex.Encode(result, rs[:])
-	return string(result)
+	return rs, nil
 }

--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -1,29 +1,42 @@
 package crypto
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 )
 
 func TestBlake(t *testing.T) {
-	r1 := Blake256("abcd")
-	if r1 != "9606e52f00c679e548b5155af5026f5af4130d7a15c990a791fff8d652c464f5" {
+	input, _ := hex.DecodeString("abcd")
+	r1, _ := Blake256(input)
+	a1, _ := hex.DecodeString("9606e52f00c679e548b5155af5026f5af4130d7a15c990a791fff8d652c464f5")
+	if 0 != bytes.Compare(r1, a1) {
 		t.Fatal("Blake256 function output error")
 	}
 
 	key1 := []byte{1, 2, 3, 4}
-	r2 := Blake128WithKey("abcd", key1)
-	if r2 != "cc98decf76abbbdf3a2027552bec09c8" {
+	r2, _ := Blake128WithKey(input, key1)
+	a2, _ := hex.DecodeString("cc98decf76abbbdf3a2027552bec09c8")
+	if 0 != bytes.Compare(r2, a2) {
 		t.Fatal("Blake128WithKey function output error")
 	}
 
+	input2, _ := hex.DecodeString("aabbccddeeff0011223344")
 	key2 := []byte{33, 65, 97, 34, 35, 36}
-	r3 := Blake160WithKey("aabbccddeeff0011223344", key2)
-	if r3 != "68e2afd80441be243c755c2184eb4c9ce9f9f17c" {
+	r3, _ := Blake160WithKey(input2, key2)
+	a3, _ := hex.DecodeString("68e2afd80441be243c755c2184eb4c9ce9f9f17c")
+	if 0 != bytes.Compare(r3, a3) {
 		t.Fatal("Blake160WithKey function output error")
 	}
 
-	r4 := Ripemd160("abcdef12345678")
-	if r4 != "6b1f9162346b8962edde6e28ee7599541def053e" {
+}
+
+func TestRipemd160(t *testing.T) {
+	input, _ := hex.DecodeString("abcdef12345678")
+	rawHash, _ := Ripemd160(input)
+	r := hex.EncodeToString(rawHash)
+	a := "6b1f9162346b8962edde6e28ee7599541def053e"
+	if r != a {
 		t.Fatal("Ripemd160 function error")
 	}
 }


### PR DESCRIPTION
This PR fixes #28.
I'm not sure whether types in RPC methods should also be changed to []byte. I'm not certain, but it seems to be that `json.Marshal()` and `json.Unmarshal()` functions only parses `JSON string` to `string` or vice versa.

## Remaining files to be changed
- [x] types.go
- [x] crypto/hash.go
- [x] ~crypto/bech32.go~