### PR TITLE
Modify ECDSA key functions

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 
 	"github.com/CodeChain-io/codechain-sdk-go/crypto"
+	"github.com/CodeChain-io/codechain-sdk-go/primitives"
 )
 
 type EcdsaKey ecdsa.PrivateKey
@@ -34,4 +35,38 @@ func (t EcdsaKey) GetPublicKey() []byte {
 	copy(rawPubKey[64-len(blobY):], blobY)
 
 	return rawPubKey
+}
+
+func (t EcdsaKey) CreateKey() (h primitives.H160, err error) {
+	hash, err := crypto.Blake160(t.GetPublicKey())
+	if err != nil {
+		return
+	}
+	return primitives.NewH160FromSlice(hash)
+}
+
+func CreateAssetAddress(networkID string) (a primitives.AssetAddress, err error) {
+	key, err := GenerateEcdsa()
+	if err != nil {
+		return
+	}
+	hash, err := key.CreateKey()
+	if err != nil {
+		return
+	}
+	return primitives.AssetAddressFromTypeAndPayload(byte(1), hash, networkID)
+}
+
+func CreatePlatformAddress(networkID string) (a primitives.PlatformAddress, secret []byte, err error) {
+	key, err := GenerateEcdsa()
+	if err != nil {
+		return
+	}
+	hash, err := key.CreateKey()
+	if err != nil {
+		return
+	}
+
+	add, err := primitives.PlatformAddressFromAccountID(hash, networkID)
+	return add, key.GetPrivateKey(), err
 }

--- a/key/key.go
+++ b/key/key.go
@@ -7,15 +7,31 @@ import (
 	"github.com/CodeChain-io/codechain-sdk-go/crypto"
 )
 
-func GenerateKey() ([]byte, error) {
+type EcdsaKey ecdsa.PrivateKey
+
+func GenerateEcdsa() (privateKey EcdsaKey, err error) {
 	privKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
-		return nil, err
+		return
 	}
+	return EcdsaKey(*privKey), nil
+}
 
+func (t EcdsaKey) GetPrivateKey() []byte {
 	rawPrivKey := make([]byte, 32)
-	blob := privKey.D.Bytes()
+	blob := t.D.Bytes()
 	copy(rawPrivKey[32-len(blob):], blob)
 
-	return rawPrivKey, nil
+	return rawPrivKey
+}
+
+func (t EcdsaKey) GetPublicKey() []byte {
+	blobX := t.PublicKey.X.Bytes()
+	blobY := t.PublicKey.Y.Bytes()
+
+	rawPubKey := make([]byte, 64)
+	copy(rawPubKey[32-len(blobX):], blobX)
+	copy(rawPubKey[64-len(blobY):], blobY)
+
+	return rawPubKey
 }

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -8,17 +8,18 @@ import (
 )
 
 func TestEcdsa(t *testing.T) {
-	key, err := GenerateKey()
+	key, err := GenerateEcdsa()
 	if err != nil {
-		t.Fatal("Fail to generate private key")
+		t.Fatal("Fail to generate ecdsa")
 	}
+	privKey := key.GetPrivateKey()
 
 	msg, err := hex.DecodeString("aabbccdd0011223344aabbccdd0011223344aabbccdd0011223344aabbccdd00")
 	if err != nil {
 		t.Fatal("Fail to decode msg")
 	}
 
-	signature := crypto.SignEcdsa(msg, key)
+	signature := crypto.SignEcdsa(msg, privKey)
 	if signature == nil {
 		t.Fatal("Signature is empty")
 	}

--- a/primitives/platformAddress.go
+++ b/primitives/platformAddress.go
@@ -3,6 +3,7 @@ package primitives
 import (
 	"encoding/hex"
 	"errors"
+
 	"golang.org/x/crypto/blake2b"
 )
 


### PR DESCRIPTION
This resolves https://github.com/CodeChain-io/codechain-sdk-go/issues/17.

Using public Key of ECDSA is necessary for the creation of platformAddress and assetAddress.