### PR TITLE
Fix MintAsset.Tracker()

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -20,13 +20,10 @@ type TransactionJSON struct {
 type TransactionInterface interface {
 	Seq() uint
 	Fee() primitives.U64
-	SetSeq(uint)
-	SetFee(primitives.U64)
 	NetworkID() string
 	ToEncodeObject() []interface{}
 	RlpBytes() []byte
 	UnsignedHash() primitives.H256
-	Sign(primitives.H256, uint, primitives.U64) SignedTransaction
 	ToJSON() TransactionJSON
 	GetType() string
 	ActionToJSON() interface{}

--- a/core/transaction/mintAsset.go
+++ b/core/transaction/mintAsset.go
@@ -51,7 +51,7 @@ func NewMintAsset(networkID string,
 }
 
 func (t MintAsset) Tracker() primitives.H256 {
-	hash, _ := crypto.Blake256(t.Transaction.RlpBytes())
+	hash, _ := crypto.Blake256(t.ActionRlpBytes())
 	return primitives.NewH256(hash)
 }
 
@@ -93,10 +93,10 @@ func (t MintAsset) GetType() string {
 }
 
 func (t MintAsset) ActionToEncodeObject() []interface{} {
-	parameters := make([][]byte, len(t.AllowedScriptHashes))
+	allowedScriptHashes := make([][]byte, len(t.AllowedScriptHashes))
 	for i, d := range t.AllowedScriptHashes {
 		res := d.ToEncodeObject()
-		parameters[i] = res
+		allowedScriptHashes[i] = res
 	}
 
 	var approver []interface{}
@@ -119,8 +119,7 @@ func (t MintAsset) ActionToEncodeObject() []interface{} {
 		t.Output.Supply.ToEncodeObject(),
 		approver,
 		registrar,
-		parameters,
-		t.Approvals}
+		allowedScriptHashes}
 }
 
 func (t MintAsset) ActionToJSON() interface{} {
@@ -136,7 +135,7 @@ func (t *MintAsset) Sign(secret primitives.H256, seq uint, fee primitives.U64) c
 }
 
 func (t MintAsset) ToEncodeObject() []interface{} {
-	return []interface{}{byte(t.Seq()), t.Fee().ToEncodeObject(), t.NetworkID(), t.ActionToEncodeObject()}
+	return []interface{}{byte(t.Seq()), t.Fee().ToEncodeObject(), t.NetworkID(), append(t.ActionToEncodeObject(), t.Approvals)}
 }
 
 func (t MintAsset) UnsignedHash() primitives.H256 {
@@ -146,5 +145,10 @@ func (t MintAsset) UnsignedHash() primitives.H256 {
 
 func (t MintAsset) RlpBytes() []byte {
 	x, _ := rlp.EncodeToBytes(t.ToEncodeObject())
+	return x
+}
+
+func (t MintAsset) ActionRlpBytes() []byte {
+	x, _ := rlp.EncodeToBytes(t.ActionToEncodeObject())
 	return x
 }


### PR DESCRIPTION
Tracker can be called as follows:
`fmt.Println(signed.Unsigned.(*MintAsset).Tracker().ToHexString())`

