### PR TITLE
Fix git action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
           fi
 
       - name: Build
-        run: go build -v .
+        run: go build -v ./...
       - name: Run Revive Action by building from repository
         uses: morphy2k/revive-action@v1
         with:


### PR DESCRIPTION
The go workflow has been always failed because there was no package in the root directory of sdk-go.