### PR TITLE
Update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CodeChain-io/codechain-sdk-go
 
-go 1.12
+go 1.13
 
 require (
 	github.com/ethereum/go-ethereum v1.9.6


### PR DESCRIPTION
[release note of go](https://golang.org/doc/go1.13)
Updated with the command `go mod edit -go=1.13`


`go test ./...` passed.
`go build./...` passed.
`go run example/transferAsset/main.go` passed.
version 1.13 already been testing by git actions.

https://github.com/CodeChain-io/codechain-sdk-go/blob/b42de8b36a1245bd39e3e12f81b1e97a03f0a4dd/.github/workflows/go.yml#L11

This resolves https://github.com/CodeChain-io/codechain-sdk-go/issues/55